### PR TITLE
gitignore intellij idea module file

### DIFF
--- a/templates/default/{%=gitignore%}
+++ b/templates/default/{%=gitignore%}
@@ -34,6 +34,7 @@ neurons
 *.sublime-workspace
 nbproject
 thumbs.db
+*.iml
 
 # Folders to ignore
 .hg


### PR DESCRIPTION
Add `*.iml` to gitignore template (intelliJ Idea module file)
There is no reason ignoring `.idea` folder but not `*.iml`
